### PR TITLE
    Streamline the volume catcher a little

### DIFF
--- a/indra/media_plugins/cef/linux/volume_catcher_linux.cpp
+++ b/indra/media_plugins/cef/linux/volume_catcher_linux.cpp
@@ -32,28 +32,29 @@
 
 VolumeCatcher::VolumeCatcher()
 {
-	// only init once we receive which implementation to use
-
-	// debugClear();
-	// debugPrint("init volume catcher\n");
 }
 
-void VolumeCatcher::onEnablePipeWireVolumeCatcher(bool enable) {
+void VolumeCatcher::onEnablePipeWireVolumeCatcher(bool enable)
+{
 	if (pimpl != nullptr)
 		return;
 
-	if (enable) {
-		// debugPrint("volume catcher using pipewire\n");
+	if (enable)
+    {
+		LL_DEBUGS() << "volume catcher using pipewire" << LL_ENDL;
 		pimpl = new VolumeCatcherPipeWire();
-	} else {
-		// debugPrint("volume catcher using pulseaudio\n");
+	}
+    else
+    {
+		LL_DEBUGS() << "volume catcher using pulseaudio" << LL_ENDL;
 		pimpl = new VolumeCatcherPulseAudio();
 	}
 }
 
 VolumeCatcher::~VolumeCatcher()
 {
-	if (pimpl != nullptr) {
+	if (pimpl != nullptr)
+    {
 		delete pimpl;
 		pimpl = nullptr;
 	}
@@ -68,15 +69,12 @@ void VolumeCatcher::setVolume(F32 volume)
 
 void VolumeCatcher::setPan(F32 pan)
 {
-	if (pimpl != nullptr) {
+	if (pimpl != nullptr)
 		pimpl->setPan(pan);
-	}
 }
 
 void VolumeCatcher::pump()
 {
-	if (pimpl != nullptr) {
+	if (pimpl != nullptr)
 		pimpl->pump();
-	}
 }
-

--- a/indra/media_plugins/cef/linux/volume_catcher_linux.cpp
+++ b/indra/media_plugins/cef/linux/volume_catcher_linux.cpp
@@ -36,45 +36,45 @@ VolumeCatcher::VolumeCatcher()
 
 void VolumeCatcher::onEnablePipeWireVolumeCatcher(bool enable)
 {
-	if (pimpl != nullptr)
-		return;
+    if (pimpl != nullptr)
+        return;
 
-	if (enable)
+    if (enable)
     {
-		LL_DEBUGS() << "volume catcher using pipewire" << LL_ENDL;
-		pimpl = new VolumeCatcherPipeWire();
-	}
+        LL_DEBUGS() << "volume catcher using pipewire" << LL_ENDL;
+        pimpl = new VolumeCatcherPipeWire();
+    }
     else
     {
-		LL_DEBUGS() << "volume catcher using pulseaudio" << LL_ENDL;
-		pimpl = new VolumeCatcherPulseAudio();
-	}
+        LL_DEBUGS() << "volume catcher using pulseaudio" << LL_ENDL;
+        pimpl = new VolumeCatcherPulseAudio();
+    }
 }
 
 VolumeCatcher::~VolumeCatcher()
 {
-	if (pimpl != nullptr)
+    if (pimpl != nullptr)
     {
-		delete pimpl;
-		pimpl = nullptr;
-	}
+        delete pimpl;
+        pimpl = nullptr;
+    }
 }
 
 void VolumeCatcher::setVolume(F32 volume)
 {
-	if (pimpl != nullptr) {
-		pimpl->setVolume(volume);
-	}
+    if (pimpl != nullptr) {
+        pimpl->setVolume(volume);
+    }
 }
 
 void VolumeCatcher::setPan(F32 pan)
 {
-	if (pimpl != nullptr)
-		pimpl->setPan(pan);
+    if (pimpl != nullptr)
+        pimpl->setPan(pan);
 }
 
 void VolumeCatcher::pump()
 {
-	if (pimpl != nullptr)
-		pimpl->pump();
+    if (pimpl != nullptr)
+        pimpl->pump();
 }

--- a/indra/media_plugins/cef/linux/volume_catcher_linux.h
+++ b/indra/media_plugins/cef/linux/volume_catcher_linux.h
@@ -49,7 +49,7 @@ extern "C" {
 
 #include "media_plugin_base.h"
 
-class VolumeCatcherPulseAudio : public virtual VolumeCatcherImpl
+class VolumeCatcherPulseAudio : public VolumeCatcherImpl
 {
 public:
 	VolumeCatcherPulseAudio();
@@ -78,7 +78,7 @@ public:
 	bool mGotSyms;
 };
 
-class VolumeCatcherPipeWire : public virtual VolumeCatcherImpl
+class VolumeCatcherPipeWire : public VolumeCatcherImpl
 {
 public:
 	VolumeCatcherPipeWire();
@@ -121,31 +121,15 @@ public:
 	F32 mVolume = 1.0f; // max by default
 	// F32 mPan = 0.0f; // center
 
-	pw_thread_loop* mThreadLoop;
-	pw_context* mContext;
-	pw_core* mCore;
-	pw_registry* mRegistry;
+	pw_thread_loop* mThreadLoop = nullptr;
+	pw_context* mContext = nullptr;
+	pw_core* mCore = nullptr;
+	pw_registry* mRegistry = nullptr;
 	spa_hook mRegistryListener;
 
 	std::unordered_set<ChildNode*> mChildNodes;
 	std::mutex mChildNodesMutex;
+    std::mutex mCleanupMutex;
 };
-
-// static void debugClear()
-// {
-// 	auto file = fopen("volume-catcher-log.txt", "w");
-// 	fprintf(file, "\n");
-// 	fclose(file);
-// }
-
-// static void debugPrint(const char* format, ...)
-// {
-//     va_list args;
-//     va_start(args, format);
-// 	auto file = fopen("volume-catcher-log.txt", "a");
-//     vfprintf(file, format, args);
-// 	fclose(file);
-//     va_end(args);
-// }
 
 #endif // VOLUME_CATCHER_LINUX_H

--- a/indra/media_plugins/cef/linux/volume_catcher_pipewire.cpp
+++ b/indra/media_plugins/cef/linux/volume_catcher_pipewire.cpp
@@ -90,9 +90,9 @@ void VolumeCatcherPipeWire::init()
 
     LL_DEBUGS() << "successfully got symbols" << LL_ENDL;
 
-	llpw_init(NULL, NULL);
+	llpw_init(nullptr, nullptr);
 
-	mThreadLoop = llpw_thread_loop_new("SL Plugin Volume Adjuster", NULL);
+	mThreadLoop = llpw_thread_loop_new("SL Plugin Volume Adjuster", nullptr);
 
 	if (!mThreadLoop)
 		return;
@@ -101,13 +101,13 @@ void VolumeCatcherPipeWire::init()
 	// std::lock_guard pwLock(*this);
 
 	mContext = llpw_context_new(
-		llpw_thread_loop_get_loop(mThreadLoop), NULL, 0
+		llpw_thread_loop_get_loop(mThreadLoop), nullptr, 0
 	);
 
 	if (!mContext)
 		return;
 
-	mCore = llpw_context_connect(mContext, NULL, 0);
+	mCore = llpw_context_connect(mContext, nullptr, 0);
 
 	if (!mCore)
 		return;

--- a/indra/media_plugins/cef/linux/volume_catcher_pulseaudio.cpp
+++ b/indra/media_plugins/cef/linux/volume_catcher_pulseaudio.cpp
@@ -57,124 +57,124 @@ SymbolGrabber paSymbolGrabber;
 
 // PulseAudio requires a chain of callbacks with C linkage
 extern "C" {
-	void callback_discovered_sinkinput(pa_context *context, const pa_sink_input_info *i, int eol, void *userdata);
-	void callback_subscription_alert(pa_context *context, pa_subscription_event_type_t t, uint32_t index, void *userdata);
-	void callback_context_state(pa_context *context, void *userdata);
+    void callback_discovered_sinkinput(pa_context *context, const pa_sink_input_info *i, int eol, void *userdata);
+    void callback_subscription_alert(pa_context *context, pa_subscription_event_type_t t, uint32_t index, void *userdata);
+    void callback_context_state(pa_context *context, void *userdata);
 }
 
 VolumeCatcherPulseAudio::VolumeCatcherPulseAudio()
-	: mDesiredVolume(0.0f),
-	  mMainloop(nullptr),
-	  mPAContext(nullptr),
-	  mConnected(false),
-	  mGotSyms(false)
+    : mDesiredVolume(0.0f),
+      mMainloop(nullptr),
+      mPAContext(nullptr),
+      mConnected(false),
+      mGotSyms(false)
 {
-	init();
+    init();
 }
 
 VolumeCatcherPulseAudio::~VolumeCatcherPulseAudio()
 {
-	cleanup();
+    cleanup();
 }
 
 bool VolumeCatcherPulseAudio::loadsyms(std::string pulse_dso_name)
 {
-	return paSymbolGrabber.grabSymbols({ pulse_dso_name });
+    return paSymbolGrabber.grabSymbols({ pulse_dso_name });
 }
 
 void VolumeCatcherPulseAudio::init()
 {
-	// try to be as defensive as possible because PA's interface is a
-	// bit fragile and (for our purposes) we'd rather simply not function
-	// than crash
+    // try to be as defensive as possible because PA's interface is a
+    // bit fragile and (for our purposes) we'd rather simply not function
+    // than crash
 
-	// we cheat and rely upon libpulse-mainloop-glib.so.0 to pull-in
-	// libpulse.so.0 - this isn't a great assumption, and the two DSOs should
-	// probably be loaded separately.  Our Linux DSO framework needs refactoring,
-	// we do this sort of thing a lot with practically identical logic...
-	mGotSyms = loadsyms("libpulse-mainloop-glib.so.0");
+    // we cheat and rely upon libpulse-mainloop-glib.so.0 to pull-in
+    // libpulse.so.0 - this isn't a great assumption, and the two DSOs should
+    // probably be loaded separately.  Our Linux DSO framework needs refactoring,
+    // we do this sort of thing a lot with practically identical logic...
+    mGotSyms = loadsyms("libpulse-mainloop-glib.so.0");
 
-	if (!mGotSyms)
-		mGotSyms = loadsyms("libpulse.so.0");
+    if (!mGotSyms)
+        mGotSyms = loadsyms("libpulse.so.0");
 
-	if (!mGotSyms)
-		return;
+    if (!mGotSyms)
+        return;
 
-	mMainloop = llpa_glib_mainloop_new(g_main_context_default());
-	
-	if (mMainloop)
-	{
-		pa_mainloop_api *api = llpa_glib_mainloop_get_api(mMainloop);
+    mMainloop = llpa_glib_mainloop_new(g_main_context_default());
 
-		if (api)
-		{
-			pa_proplist *proplist = llpa_proplist_new();
+    if (mMainloop)
+    {
+        pa_mainloop_api *api = llpa_glib_mainloop_get_api(mMainloop);
 
-			if (proplist)
-			{
-				llpa_proplist_sets(proplist, PA_PROP_APPLICATION_ICON_NAME, "multimedia-player");
-				llpa_proplist_sets(proplist, PA_PROP_APPLICATION_ID, "com.secondlife.viewer.mediaplugvoladjust");
-				llpa_proplist_sets(proplist, PA_PROP_APPLICATION_NAME, "SL Plugin Volume Adjuster");
-				llpa_proplist_sets(proplist, PA_PROP_APPLICATION_VERSION, "1");
+        if (api)
+        {
+            pa_proplist *proplist = llpa_proplist_new();
 
-				// plain old pa_context_new() is broken!
-				mPAContext = llpa_context_new_with_proplist(api, nullptr, proplist);
+            if (proplist)
+            {
+                llpa_proplist_sets(proplist, PA_PROP_APPLICATION_ICON_NAME, "multimedia-player");
+                llpa_proplist_sets(proplist, PA_PROP_APPLICATION_ID, "com.secondlife.viewer.mediaplugvoladjust");
+                llpa_proplist_sets(proplist, PA_PROP_APPLICATION_NAME, "SL Plugin Volume Adjuster");
+                llpa_proplist_sets(proplist, PA_PROP_APPLICATION_VERSION, "1");
 
-				llpa_proplist_free(proplist);
-			}
-		}
-	}
+                // plain old pa_context_new() is broken!
+                mPAContext = llpa_context_new_with_proplist(api, nullptr, proplist);
 
-	// Now we've set up a PA context and mainloop, try connecting the
-	// PA context to a PA daemon.
-	if (mPAContext)
-	{
-		llpa_context_set_state_callback(mPAContext, callback_context_state, this);
-		pa_context_flags_t cflags = (pa_context_flags)0; // maybe add PA_CONTEXT_NOAUTOSPAWN?
-		if (llpa_context_connect(mPAContext, nullptr, cflags, nullptr) >= 0)
-		{
-			// Okay!  We haven't definitely connected, but we
-			// haven't definitely failed yet.
-		}
-		else
-		{
-			// Failed to connect to PA manager... we'll leave
-			// things like that.  Perhaps we should try again later.
-		}
-	}
+                llpa_proplist_free(proplist);
+            }
+        }
+    }
+
+    // Now we've set up a PA context and mainloop, try connecting the
+    // PA context to a PA daemon.
+    if (mPAContext)
+    {
+        llpa_context_set_state_callback(mPAContext, callback_context_state, this);
+        pa_context_flags_t cflags = (pa_context_flags)0; // maybe add PA_CONTEXT_NOAUTOSPAWN?
+        if (llpa_context_connect(mPAContext, nullptr, cflags, nullptr) >= 0)
+        {
+            // Okay!  We haven't definitely connected, but we
+            // haven't definitely failed yet.
+        }
+        else
+        {
+            // Failed to connect to PA manager... we'll leave
+            // things like that.  Perhaps we should try again later.
+        }
+    }
 }
 
 void VolumeCatcherPulseAudio::cleanup()
 {
-	mConnected = false;
+    mConnected = false;
 
-	if (mGotSyms && mPAContext)
-	{
-		llpa_context_disconnect(mPAContext);
-		llpa_context_unref(mPAContext);
-	}
+    if (mGotSyms && mPAContext)
+    {
+        llpa_context_disconnect(mPAContext);
+        llpa_context_unref(mPAContext);
+    }
 
-	mPAContext = nullptr;
+    mPAContext = nullptr;
 
-	if (mGotSyms && mMainloop)
-		llpa_glib_mainloop_free(mMainloop);
+    if (mGotSyms && mMainloop)
+        llpa_glib_mainloop_free(mMainloop);
 
-	mMainloop = nullptr;
+    mMainloop = nullptr;
 }
 
 void VolumeCatcherPulseAudio::setVolume(F32 volume)
 {
-	mDesiredVolume = volume;
-	
-	if (!mGotSyms)
-		return;
+    mDesiredVolume = volume;
 
-	if (mConnected && mPAContext)
-	{
-		update_all_volumes(mDesiredVolume);
-	}
+    if (!mGotSyms)
+        return;
 
-	pump();
+    if (mConnected && mPAContext)
+    {
+        update_all_volumes(mDesiredVolume);
+    }
+
+    pump();
 }
 
 void VolumeCatcherPulseAudio::setPan(F32 pan)
@@ -183,140 +183,140 @@ void VolumeCatcherPulseAudio::setPan(F32 pan)
 
 void VolumeCatcherPulseAudio::pump()
 {
-	gboolean may_block = FALSE;
-	g_main_context_iteration(g_main_context_default(), may_block);
+    gboolean may_block = FALSE;
+    g_main_context_iteration(g_main_context_default(), may_block);
 }
 
 void VolumeCatcherPulseAudio::connected_okay()
 {
-	pa_operation *op;
+    pa_operation *op;
 
-	// fetch global list of existing sinkinputs
-	if ((op = llpa_context_get_sink_input_info_list(mPAContext,
-							callback_discovered_sinkinput,
-							this)))
-	{
-		llpa_operation_unref(op);
-	}
+    // fetch global list of existing sinkinputs
+    if ((op = llpa_context_get_sink_input_info_list(mPAContext,
+                            callback_discovered_sinkinput,
+                            this)))
+    {
+        llpa_operation_unref(op);
+    }
 
-	// subscribe to future global sinkinput changes
-	llpa_context_set_subscribe_callback(mPAContext,
-					    callback_subscription_alert,
-					    this);
-	if ((op = llpa_context_subscribe(mPAContext, (pa_subscription_mask_t)
-					 (PA_SUBSCRIPTION_MASK_SINK_INPUT),
+    // subscribe to future global sinkinput changes
+    llpa_context_set_subscribe_callback(mPAContext,
+                        callback_subscription_alert,
+                        this);
+    if ((op = llpa_context_subscribe(mPAContext, (pa_subscription_mask_t)
+                     (PA_SUBSCRIPTION_MASK_SINK_INPUT),
                                      nullptr, nullptr)))
-	{
-		llpa_operation_unref(op);
-	}
+    {
+        llpa_operation_unref(op);
+    }
 }
 
 void VolumeCatcherPulseAudio::update_all_volumes(F32 volume)
 {
-	for (std::set<U32>::iterator it = mSinkInputIndices.begin();
-	     it != mSinkInputIndices.end(); ++it)
-	{
-		update_index_volume(*it, volume);
-	}
+    for (std::set<U32>::iterator it = mSinkInputIndices.begin();
+         it != mSinkInputIndices.end(); ++it)
+    {
+        update_index_volume(*it, volume);
+    }
 }
 
 void VolumeCatcherPulseAudio::update_index_volume(U32 index, F32 volume)
 {
-	static pa_cvolume cvol;
-	llpa_cvolume_set(&cvol, mSinkInputNumChannels[index],
-			 llpa_sw_volume_from_linear(volume));
-	
-	pa_context *c = mPAContext;
-	uint32_t idx = index;
-	const pa_cvolume *cvolumep = &cvol;
-	pa_context_success_cb_t cb = nullptr; // okay as null
-	void *userdata = nullptr; // okay as null
+    static pa_cvolume cvol;
+    llpa_cvolume_set(&cvol, mSinkInputNumChannels[index],
+             llpa_sw_volume_from_linear(volume));
 
-	pa_operation *op;
-	if ((op = llpa_context_set_sink_input_volume(c, idx, cvolumep, cb, userdata)))
-		llpa_operation_unref(op);
+    pa_context *c = mPAContext;
+    uint32_t idx = index;
+    const pa_cvolume *cvolumep = &cvol;
+    pa_context_success_cb_t cb = nullptr; // okay as null
+    void *userdata = nullptr; // okay as null
+
+    pa_operation *op;
+    if ((op = llpa_context_set_sink_input_volume(c, idx, cvolumep, cb, userdata)))
+        llpa_operation_unref(op);
 }
 
 void callback_discovered_sinkinput(pa_context *context, const pa_sink_input_info *sii, int eol, void *userdata)
 {
-	VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
-	llassert(impl);
+    VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
+    llassert(impl);
 
-	if (0 == eol)
-	{
-		pa_proplist *proplist = sii->proplist;
-		pid_t sinkpid = atoll(llpa_proplist_gets(proplist, PA_PROP_APPLICATION_PROCESS_ID));
+    if (0 == eol)
+    {
+        pa_proplist *proplist = sii->proplist;
+        pid_t sinkpid = atoll(llpa_proplist_gets(proplist, PA_PROP_APPLICATION_PROCESS_ID));
 
-		if (isPluginPid( sinkpid )) // does the discovered sinkinput belong to this process?
-		{
-			bool is_new = (impl->mSinkInputIndices.find(sii->index) == impl->mSinkInputIndices.end());
-			
-			impl->mSinkInputIndices.insert(sii->index);
-			impl->mSinkInputNumChannels[sii->index] = sii->channel_map.channels;
-			
-			if (is_new)
-			{
-				// new!
-				impl->update_index_volume(sii->index, impl->mDesiredVolume);
-			}
-			else
-			{
-				// seen it already, do nothing.
-			}
-		}
-	}
+        if (isPluginPid( sinkpid )) // does the discovered sinkinput belong to this process?
+        {
+            bool is_new = (impl->mSinkInputIndices.find(sii->index) == impl->mSinkInputIndices.end());
+
+            impl->mSinkInputIndices.insert(sii->index);
+            impl->mSinkInputNumChannels[sii->index] = sii->channel_map.channels;
+
+            if (is_new)
+            {
+                // new!
+                impl->update_index_volume(sii->index, impl->mDesiredVolume);
+            }
+            else
+            {
+                // seen it already, do nothing.
+            }
+        }
+    }
 }
 
 void callback_subscription_alert(pa_context *context, pa_subscription_event_type_t t, uint32_t index, void *userdata)
 {
-	VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
-	llassert(impl);
+    VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
+    llassert(impl);
 
-	switch (t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK)
-	{
+    switch (t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK)
+    {
         case PA_SUBSCRIPTION_EVENT_SINK_INPUT:
-			if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) ==  PA_SUBSCRIPTION_EVENT_REMOVE)
-			{
-				// forget this sinkinput, if we were caring about it
-				impl->mSinkInputIndices.erase(index);
-				impl->mSinkInputNumChannels.erase(index);
-			}
-			else if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_NEW)
-			{
-				// ask for more info about this new sinkinput
-				pa_operation *op;
-				if ((op = llpa_context_get_sink_input_info(impl->mPAContext, index, callback_discovered_sinkinput, impl)))
-				{
-					llpa_operation_unref(op);
-				}
-			}
-			else
-			{
-				// property change on this sinkinput - we don't care.
-			}
-			break;
-		
-		default:;
-	}
+            if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) ==  PA_SUBSCRIPTION_EVENT_REMOVE)
+            {
+                // forget this sinkinput, if we were caring about it
+                impl->mSinkInputIndices.erase(index);
+                impl->mSinkInputNumChannels.erase(index);
+            }
+            else if ((t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) == PA_SUBSCRIPTION_EVENT_NEW)
+            {
+                // ask for more info about this new sinkinput
+                pa_operation *op;
+                if ((op = llpa_context_get_sink_input_info(impl->mPAContext, index, callback_discovered_sinkinput, impl)))
+                {
+                    llpa_operation_unref(op);
+                }
+            }
+            else
+            {
+                // property change on this sinkinput - we don't care.
+            }
+            break;
+
+        default:;
+    }
 }
 
 void callback_context_state(pa_context *context, void *userdata)
 {
-	VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
-	llassert(impl);
-	
-	switch (llpa_context_get_state(context))
-	{
-	case PA_CONTEXT_READY:
-		impl->mConnected = true;
-		impl->connected_okay();
-		break;
-	case PA_CONTEXT_TERMINATED:
-		impl->mConnected = false;
-		break;
-	case PA_CONTEXT_FAILED:
-		impl->mConnected = false;
-		break;
-	default:;
-	}
+    VolumeCatcherPulseAudio *impl = dynamic_cast<VolumeCatcherPulseAudio*>((VolumeCatcherPulseAudio*)userdata);
+    llassert(impl);
+
+    switch (llpa_context_get_state(context))
+    {
+    case PA_CONTEXT_READY:
+        impl->mConnected = true;
+        impl->connected_okay();
+        break;
+    case PA_CONTEXT_TERMINATED:
+        impl->mConnected = false;
+        break;
+    case PA_CONTEXT_FAILED:
+        impl->mConnected = false;
+        break;
+    default:;
+    }
 }

--- a/indra/media_plugins/cef/volume_catcher.h
+++ b/indra/media_plugins/cef/volume_catcher.h
@@ -43,7 +43,7 @@ public:
 	virtual void pump() = 0; // call this at least a few times a second if you can - it affects how quickly we can 'catch' a new audio source and adjust its volume
 };
 
-class VolumeCatcher : public virtual VolumeCatcherImpl
+class VolumeCatcher : public VolumeCatcherImpl
 {
 public:
 	VolumeCatcher();


### PR DESCRIPTION

    - Use LL_DEBUGS() for potential debug output.
    - Enclose mutex locking in their own scope, to make unlocking automatic and also limit the life time of a lock to as short as possible
    - Introduce mCleanupMutex to replace std::unique_lock pwLock(*this). I'm baffled using lock as a mutex like that did even compile.
    - Remove virtual inheritance, as it is not needed here.
    - Tabs to spaces
    - Replace a few NULL with nullptr